### PR TITLE
Feature flags ["libz", "highs_release", "ninja"]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ keywords = ["linear-programming", "optimization", "math", "solver"]
 [build-dependencies]
 bindgen = "0.63.0"
 cmake = "0.1.49"
+
+[features]
+highs_release = []

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ winget install -e --id Kitware.CMake
 winget install -e --id LLVM.LLVM
 ```
 
+#### Feature Flags
+
+`highs_release`: set CMake profile to "Release" regardless of build profile.
+`libz`: enable HiGHS libz linking to enable support for reading 'mps.gz'.
+`ninja`: set CMake generator to Ninja.
+
+Windows users will likely need to install libz and set the ZLIB_ROOT
+environment variable for CMake to locate and link with the library.
+
+Ninja is available in [winget](https://winget.run/).
+
+```powershell
+winget install -e --id Ninja-build.Ninja
+```
+
 HiGHS itself is built statically, so you don't need to install it
 separately on the target system.
 

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,14 @@ use std::path::PathBuf;
 use cmake::Config;
 
 fn main() {
-    let dst = Config::new("HiGHS")
+    let mut dst = Config::new("HiGHS");
+
+    // Avoid using downstream project's profile setting for HiGHS build.
+    if cfg!(feature = "highs_release") {
+        dst.profile("Release");
+    }
+
+    let dst = dst
         .define("FAST_BUILD", "ON")
         .define("SHARED", "OFF")
         .define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreadedDLL")


### PR DESCRIPTION
With these three feature flags we

- enable HiGHS gz support, which is usable by linking libz in the user's app.
- provide the ability for a user's app to use whatever profile they need for their app work while still building a Release HiGHS build.
- provide the ability to set the CMake generator to Ninja, which enables Windows users to actually build a Release build that sets NDEBUG on Release and RelWithDebInfo builds.

HiGHS cmake will pick up the libz using its normal libz search, on Windows setting LIBZ_ROOT and adding libz-sys to the user's app works.
Ninja generator allows the build flags to be properly setup without the flag merging conflicts that happen with the msvc generator.