### PR TITLE
Remove dependency on OpenMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,14 @@ How you install these depends on your operating system.
 #### Debian
 
 ```
-sudo apt-get install libstdc++6 libgomp1
+sudo apt-get install libstdc++6
 ```
 
 (These are probably already installed on your system)
 
 #### macOS
 
-```
-brew install libomp
-```
+The required libraries should already be installed.
 
 ### Building HiGHS
 

--- a/build.rs
+++ b/build.rs
@@ -73,12 +73,6 @@ fn build() -> bool {
     } else if linux {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
-    if apple {
-        println!("cargo:rustc-link-lib=dylib=omp");
-    } else if !windows {
-        // No openmp 3 on windows
-        println!("cargo:rustc-link-lib=dylib=gomp");
-    }
     println!("cargo:rerun-if-changed=HiGHS/src/interfaces/highs_c_api.h");
 
     true

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,11 +1,10 @@
 set -x
 if test -x "$(which apt-get)"; then
-  sudo apt-get install libstdc++6 libgomp1 cmake
+  sudo apt-get install libstdc++6 cmake
 elif test -x "$(which dnf)"; then
-  sudo dnf install libstdc++ libgomp cmake
+  sudo dnf install libstdc++ cmake
 elif test -x "$(which brew)"; then
-  brew install libomp cmake
-  brew link --force libomp
+  echo "Nothing to instal on MacOS"
 else
   echo "system not supported"
   exit 1


### PR DESCRIPTION
Following discussions on the [rust-or/highs issue](https://github.com/rust-or/highs/issues/11).

Indeed the OpenMP dependency does not seem required anymore.