### PR TITLE
Link libstdc++ on mingw targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -63,9 +63,10 @@ fn build() -> bool {
     let target = env::var("TARGET").unwrap();
     let apple = target.contains("apple");
     let linux = target.contains("linux");
+    let mingw = target.contains("pc-windows-gnu");
     if apple {
         println!("cargo:rustc-link-lib=dylib=c++");
-    } else if linux {
+    } else if linux || mingw {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
     println!("cargo:rerun-if-changed=HiGHS/src/interfaces/highs_c_api.h");


### PR DESCRIPTION
Without this, users compiling for mingw (either natively or cross-compiling) get linker errors.
Tested from ubuntu 20.04:

```system
sudo apt install mingw-w64-x86-64-dev mingw-w64
rustup target add x86_64-pc-windows-gnu
cargo build --target x86_64-pc-windows-gnu
```