### PR TITLE
Fix build script -- the file has been renamed in HiGHS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn build() -> bool {
     } else if linux || mingw {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
-    println!("cargo:rerun-if-changed=HiGHS/src/interfaces/highs_c_api.h");
+    println!("cargo:rerun-if-changed=HiGHS/highs/interfaces/highs_c_api.h");
 
     true
 }


### PR DESCRIPTION
Currently running `cargo check` in `highs-sys` directory will rebuild HiGHS every time. Running with `CARGO_LOG=cargo::core::compiler::fingerprint=info cargo check` reveals that the path for `highs_c_api.h` is wrong.