### PR TITLE
[codex] add sccache to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  CMAKE_C_COMPILER_LAUNCHER: sccache
+  CMAKE_CXX_COMPILER_LAUNCHER: sccache
 
 jobs:
   build:
@@ -31,6 +35,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
     - name: install dependencies
@@ -54,6 +60,8 @@ jobs:
         cd ..
         cargo clean
         cargo build --no-default-features --features "discover"
+    - name: Show sccache stats
+      run: sccache --show-stats
 
   wasm-emscripten:
     runs-on: ubuntu-latest
@@ -64,6 +72,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
     - name: Setup emsdk
@@ -75,3 +85,5 @@ jobs:
       run: |
         rustup target add wasm32-unknown-emscripten
         cargo build --target wasm32-unknown-emscripten
+    - name: Show sccache stats
+      run: sccache --show-stats


### PR DESCRIPTION
## Summary

Enable `sccache` in GitHub Actions so CI can cache Rust compilation outputs and CMake-driven C/C++ compilation outputs across runs.

## Changes

- install `mozilla-actions/sccache-action` in both workflow jobs
- set `RUSTC_WRAPPER=sccache` and `SCCACHE_GHA_ENABLED=true`
- set `CMAKE_C_COMPILER_LAUNCHER=sccache` and `CMAKE_CXX_COMPILER_LAUNCHER=sccache` through the workflow environment
- print `sccache --show-stats` at the end of each job for visibility

## Why

Most of the expensive CI time is spent compiling the bundled HiGHS C++ sources. `Swatinem/rust-cache` helps with Cargo downloads and dependency artifacts, but `sccache` is the relevant cache layer for repeated compiler invocations from both Rust and the CMake build.

## Validation

- local: `cargo test`
- CI: not yet run on this branch at PR creation time
