### PR TITLE
Update HiGHS to v1.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highs-sys"
-version = "1.14.3"
+version = "1.15.0"
 authors = ["Ophir LOJKINE"]
 edition = "2018"
 description = "Rust binding for the HiGHS linear programming solver. See http://highs.dev."


### PR DESCRIPTION
bumps the HiGHS submodule to https://github.com/ERGO-Code/HiGHS/commit/83960019015b0d5152df73110ff142f328edcfd2 which is the commit v1.15.0 is tagged with. also bumps the version of the crate to `1.15.0` to match